### PR TITLE
Генерация описания для деклараций типа function test ($a, $b) {$a}

### DIFF
--- a/ITG.Readme.psm1
+++ b/ITG.Readme.psm1
@@ -83,12 +83,6 @@
 	process {
 		switch ( $PsCmdlet.ParameterSetName ) {
 			'ModuleInfo' {
-				$Funcs = @( `
-					$ModuleInfo.ExportedFunctions.Values `
-					| Sort-Object -Property `
-						@{ Expression={ ( $_.Name -split '-' )[1] } } `
-						, @{ Expression={ ( $_.Name -split '-' )[0] } } `
-				);
 				$ReadMeContent = & { `
 @"
 $($ModuleInfo.Name)
@@ -98,8 +92,11 @@ $($ModuleInfo.Description)
 
 Версия модуля: **$( $ModuleInfo.Version.ToString() )**
 "@
-					if ( $Funcs.Count ) {
-						$Funcs `
+					if ( $ModuleInfo.ExportedFunctions ) {
+						$ModuleInfo.ExportedFunctions.Values `
+						| Sort-Object -Property `
+							@{ Expression={ ( $_.Name -split '-' )[1] } } `
+							, @{ Expression={ ( $_.Name -split '-' )[0] } } `
 						| Group-Object -Property `
 							@{ Expression={ ( $_.Name -split '-' )[1] } } `
 						| % -Begin {
@@ -125,7 +122,10 @@ $($ModuleInfo.Description)
 Подробное описание функций модуля
 ---------------------------------
 "@
-							$Funcs `
+							$ModuleInfo.ExportedFunctions.Values `
+							| Sort-Object -Property `
+								@{ Expression={ ( $_.Name -split '-' )[1] } } `
+								, @{ Expression={ ( $_.Name -split '-' )[0] } } `
 							| Get-Readme `
 							;
 						};

--- a/ITG.Readme.psm1
+++ b/ITG.Readme.psm1
@@ -107,10 +107,12 @@ $($ModuleInfo.Description)
 "@
 						} `
 						-Process {
+							if ( $_.Name ) {
 @"
 			
 ### $($_.Name)
 "@
+							};
 							$_.Group `
 							| Get-Readme -ShortDescription `
 							;
@@ -150,35 +152,39 @@ $($ModuleInfo.Description)
 			}
 			'FunctionInfo' {
 				$Help = ( $FunctionInfo | Get-Help -Full );
-				$Syntax = (
-					$Help.Syntax.SyntaxItem `
-					| % {
-						,$_.Name `
-						+ ( 
-							$_.Parameter `
-							| % {
-								#MamlCommandHelpInfo#parameter
-								$name="-$($_.Name)";
-								if ( $_.position -ne 'named' ) {
-									$name="[$name]";
-								};
-								if ( $_.parameterValue ) {
-									$param = "$name <$($_.parameterValue)>";
-								} else {
-									$param = "$name";
-								};
-								if ( $_.required -ne 'true' ) {
-									$param = "[$param]";
-								};
-								$param;
-							}
-						) `
-						+ ( & {
-							if ( $FunctionInfo.CmdletBinding ) { '<CommonParameters>' }
-						} ) `
-						-join ' '
-					}
-				);
+				if ( $Help.Syntax ) {
+					$Syntax = (
+						$Help.Syntax.SyntaxItem `
+						| % {
+							,$_.Name `
+							+ ( 
+								$_.Parameter `
+								| % {
+									#MamlCommandHelpInfo#parameter
+									$name="-$($_.Name)";
+									if ( $_.position -ne 'named' ) {
+										$name="[$name]";
+									};
+									if ( $_.parameterValue ) {
+										$param = "$name <$($_.parameterValue)>";
+									} else {
+										$param = "$name";
+									};
+									if ( $_.required -ne 'true' ) {
+										$param = "[$param]";
+									};
+									$param;
+								}
+							) `
+							+ ( & {
+								if ( $FunctionInfo.CmdletBinding ) { '<CommonParameters>' }
+							} ) `
+							-join ' '
+						}
+					);
+				} else {
+					$Syntax = $Help.Synopsis;
+				};
 @"
 			
 #### $($FunctionInfo.Name)
@@ -186,12 +192,14 @@ $($ModuleInfo.Description)
 "@
 				if ( $ShortDescription ) {
 					$Help.Synopsis;
-					$Syntax `
-					| % {
+					if ( $Help.Syntax ) {
+						$Syntax `
+						| % {
 @"
 	
 	$_
 "@
+						};
 					};
 				} else {
 					if ( $Help.Description ) {


### PR DESCRIPTION
Исправил генерацию описания для деклараций функций типа

```
function test ($a, $b) {$a}
```

Теперь генерирую простейшее описание, содержащее только синтаксис вызова функции.
