### PR TITLE
Убрать генерацию перекрёстных ссылок в коде

### DIFF
--- a/ITG.Readme.psm1
+++ b/ITG.Readme.psm1
@@ -288,7 +288,7 @@ Function Get-Readme {
 							template = New-Object `
 								-TypeName System.Text.RegularExpressions.Regex `
 								-ArgumentList `
-									"(?<!\w|[`[#`t])(?<func>$($_.Name))(?!\w)" `
+									"(?<!\w|[`[#]|`t+.*?)(?<func>$($_.Name))(?!\w)" `
 									, (
 										[System.Text.RegularExpressions.RegexOptions]::IgnoreCase `
 										-bor [System.Text.RegularExpressions.RegexOptions]::Multiline `

--- a/readme.md
+++ b/readme.md
@@ -131,12 +131,12 @@ String
 1. Генерация readme.md файла для модуля `ITG.Yandex.DnsServer`
 в текущем каталоге.
 
-		Get-Module 'ITG.Yandex.DnsServer' | [Get-Readme][] | Out-File -Path 'readme.md' -Encoding 'UTF8' -Width 1024;
+		Get-Module 'ITG.Yandex.DnsServer' | Get-Readme | Out-File -Path 'readme.md' -Encoding 'UTF8' -Width 1024;
 
 2. Генерация readme.md файла для модуля `ITG.Yandex.DnsServer`
 в каталоге модуля.
 
-		Get-Module 'ITG.Yandex.DnsServer' | [Get-Readme][] -OutDefaultFile;
+		Get-Module 'ITG.Yandex.DnsServer' | Get-Readme -OutDefaultFile;
 
 ##### Связанные ссылки
 


### PR DESCRIPTION
- убрал генерацию .md перекрёстных ссылок в коде (точнее - пока только в строках, содержащих табуляцию. Над регулярным выражением ещё следует поработать)
