### PR TITLE
Исправлены ошибки в test.ps1 при переходе на PoSh 3

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -1,13 +1,12 @@
 ﻿[CmdletBinding()]
 param()
 
-$Module = Import-Module `
+Import-Module `
 	(Join-Path `
 		-Path ( Split-Path -Path ( $MyInvocation.MyCommand.Path ) -Parent ) `
-		-ChildPath 'ITG.Readme' `
+		-ChildPath 'ITG.Readme.psd1' `
 	) `
 	-Force `
 	-Verbose `
-	-PassThru `
 ;
-Get-Readme -Module $Module -OutDefaultFile;
+Get-Readme -Module ( Get-Module 'ITG.Readme' ) -OutDefaultFile;


### PR DESCRIPTION
Первая ошибка вызвана тем, что PoSh 3 теперь требует явного указания файла для загрузки модуля - добавил расширение .psd1.

Вторая ошибка связана с тем, что в PoSh 3 `Import-Module` возвращает дескриптор не только явно загружаемого модуля, но и всех тех, что были загружены уже по требованию самого модуля. В нашем случае - ITG.PrepareModulesEnv.ps1.
#63
