### PR TITLE
Get-HelpInfo - возвращает XmlDocument файла HelpInfo.xml для указанного модуля

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,14 @@
 
 ### HelpInfo
 
+#### Обзор [Get-HelpInfo][]
+
+Возвращает HelpInfo.xml (как xml) для указанного модуля.
+
+	Get-HelpInfo [-ModuleInfo] <PSModuleInfo> <CommonParameters>
+
+Подробнее - [Get-HelpInfo][].
+
 #### Обзор [New-HelpInfo][]
 
 Генерирует HelpInfo XML для переданного модуля.
@@ -52,6 +60,66 @@
 
 Подробное описание функций модуля
 ---------------------------------
+
+#### Get-HelpInfo
+
+Вычисляет наименование и положение HelpInfo.xml файла для указанного модуля
+и возвращает его содержимое. Если файл не обнаружен - возвращает пустую
+xml "заготовку" HelpInfo.xml, но валидную.
+
+##### Синтаксис
+
+	Get-HelpInfo [-ModuleInfo] <PSModuleInfo> <CommonParameters>
+
+##### Требуемая роль пользователя
+
+Для выполнения функции Get-HelpInfo требуется роль Everyone для учётной записи,
+от имени которой будет выполнена описываемая функция.
+
+##### Принимаемые данные по конвейеру
+
+- System.Management.Automation.PSModuleInfo
+Описатели модулей. Именно для них и будет возвращён манифест XML справки (HelpInfo.xml).
+Получены описатели могут быть через `Get-Module`.
+
+##### Передаваемые по конвейеру данные
+
+- System.Xml.XmlDocument
+Содержимое XML манифеста (HelpInfo.xml) справки.
+
+##### Параметры
+
+- `ModuleInfo <PSModuleInfo>`
+        Описатель модуля
+
+        Требуется? true
+        Позиция? 1
+        Значение по умолчанию
+        Принимать входные данные конвейера?true (ByValue)
+        Принимать подстановочные знаки?
+
+- `<CommonParameters>`
+        Данный командлет поддерживает общие параметры: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer и OutVariable. Для получения дополнительных сведений введите
+        [`get-help about_CommonParameters`][about_CommonParameters].
+
+
+
+##### Примеры использования
+
+1. Возвращает xml манифест справки для модуля `ITG.Yandex.DnsServer`.
+
+		Get-Module 'ITG.Yandex.DnsServer' | Get-HelpInfo;
+
+##### См. также
+
+- [Online версия справки](http://github.com/IT-Service/ITG.Readme#Get-HelpInfo)
+- about_Updatable_Help
+- Set-HelpInfo
+- [New-HelpInfo][]
+- [How to Name a HelpInfo XML File](http://msdn.microsoft.com/en-us/library/windows/desktop/hh852748.aspx)
+- [HelpInfo XML Sample File](http://msdn.microsoft.com/en-us/library/windows/desktop/hh852750.aspx)
 
 #### New-HelpInfo
 
@@ -114,9 +182,9 @@ HelpInfo.XML по сути является манифестом для xml сп
 
 ##### См. также
 
-- [Online версия справки](http://github.com/IT-Service/ITG.Readme#New-HelpInfoXML)
+- [Online версия справки](http://github.com/IT-Service/ITG.Readme#New-HelpInfo)
 - about_Updatable_Help
-- Set-HelpInfoXML
+- Set-HelpInfo
 - [HelpInfo XML Sample File](http://msdn.microsoft.com/en-us/library/windows/desktop/hh852750.aspx)
 
 #### Get-HelpXML
@@ -352,6 +420,7 @@ Readme
 
 [about_Comment_Based_Help]: http://go.microsoft.com/fwlink/?LinkID=144309 
 [about_CommonParameters]: http://go.microsoft.com/fwlink/?LinkID=113216 
+[Get-HelpInfo]: <ITG.Readme#Get-HelpInfo> "Возвращает HelpInfo.xml (как xml) для указанного модуля."
 [Get-HelpXML]: <ITG.Readme#Get-HelpXML> "Генерирует XML справку для переданного модуля, функции, командлеты."
 [Get-Readme]: <ITG.Readme#Get-Readme> "Генерирует readme файл с MarkDown разметкой по данным модуля и комментариям к его функциям. Файл предназначен, в частности, для размещения в репозиториях github."
 [MarkDown]: http://daringfireball.net/projects/markdown/syntax "MarkDown (md) Syntax"

--- a/ru-RU/ITG.Readme.psm1-help.xml
+++ b/ru-RU/ITG.Readme.psm1-help.xml
@@ -3,6 +3,100 @@
 <helpItems xmlns="http://msh" xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" schema="maml">
 	<command xmlns:msh="http://msh" xmlns="http://schemas.microsoft.com/maml/dev/command/2004/10">
 		<details>
+			<name>Get-HelpInfo</name>
+			<verb>Get</verb>
+			<noun>HelpInfo</noun>
+			<maml:description>
+				<maml:para>Возвращает HelpInfo.xml (как xml) для указанного модуля.</maml:para>
+			</maml:description>
+			<maml:copyright>
+				<maml:para>(c) 2012 Sergey S. Betke. All rights reserved.</maml:para>
+			</maml:copyright>
+			<dev:version>1.6.3</dev:version>
+		</details>
+		<maml:role>Everyone</maml:role>
+		<maml:description>
+			<maml:para>Вычисляет наименование и положение HelpInfo.xml файла для указанного модуля и возвращает его содержимое. Если файл не обнаружен - возвращает пустую xml "заготовку" HelpInfo.xml, но валидную.</maml:para>
+		</maml:description>
+		<syntax>
+			<syntaxItem>
+				<maml:name>Get-HelpInfo</maml:name>
+				<parameter required="true" position="1" pipelineInput="true (ByValue)">
+					<maml:name>ModuleInfo</maml:name>
+					<parameterValue required="true">PSModuleInfo</parameterValue>
+				</parameter>
+			</syntaxItem>
+		</syntax>
+		<parameters>
+			<parameter required="true" position="1" pipelineInput="true (ByValue)">
+				<maml:name>ModuleInfo</maml:name>
+				<maml:description>
+					<maml:para>Описатель модуля</maml:para>
+				</maml:description>
+				<parameterValue required="True">PSModuleInfo</parameterValue>
+			</parameter>
+		</parameters>
+		<inputTypes>
+			<inputType>
+				<dev:type>
+					<maml:name>System.Management.Automation.PSModuleInfo</maml:name>
+					<maml:description>
+						<maml:para>Описатели модулей. Именно для них и будет возвращён манифест XML справки (HelpInfo.xml). Получены описатели могут быть через `Get-Module`.</maml:para>
+					</maml:description>
+				</dev:type>
+				<maml:description>
+					<maml:para>Описатели модулей. Именно для них и будет возвращён манифест XML справки (HelpInfo.xml). Получены описатели могут быть через `Get-Module`.</maml:para>
+				</maml:description>
+			</inputType>
+		</inputTypes>
+		<returnValues>
+			<returnValue>
+				<dev:type>
+					<maml:name>System.Xml.XmlDocument</maml:name>
+					<maml:description>
+						<maml:para>Содержимое XML манифеста (HelpInfo.xml) справки.</maml:para>
+					</maml:description>
+				</dev:type>
+				<maml:description>
+					<maml:para>Содержимое XML манифеста (HelpInfo.xml) справки.</maml:para>
+				</maml:description>
+			</returnValue>
+		</returnValues>
+		<examples>
+			<example>
+				<maml:title>-------------------------- ПРИМЕР 1 --------------------------</maml:title>
+				<maml:introduction>
+					<maml:paragraph>C:\PS&gt;</maml:paragraph>
+				</maml:introduction>
+				<dev:code>Get-Module 'ITG.Yandex.DnsServer' | Get-HelpInfo;</dev:code>
+				<maml:remarks>
+					<maml:para>Возвращает xml манифест справки для модуля `ITG.Yandex.DnsServer`.</maml:para>
+				</maml:remarks>
+			</example>
+		</examples>
+		<maml:relatedLinks>
+			<maml:navigationLink>
+				<maml:linkText>about_Updatable_Help</maml:linkText>
+			</maml:navigationLink>
+			<maml:navigationLink>
+				<maml:linkText>Set-HelpInfo</maml:linkText>
+			</maml:navigationLink>
+			<maml:navigationLink>
+				<maml:linkText>New-HelpInfo</maml:linkText>
+			</maml:navigationLink>
+			<maml:navigationLink>
+				<maml:uri>http://github.com/IT-Service/ITG.Readme#Get-HelpInfo</maml:uri>
+			</maml:navigationLink>
+			<maml:navigationLink>
+				<maml:linkText>[How to Name a HelpInfo XML File](http://msdn.microsoft.com/en-us/library/windows/desktop/hh852748.aspx)</maml:linkText>
+			</maml:navigationLink>
+			<maml:navigationLink>
+				<maml:linkText>[HelpInfo XML Sample File](http://msdn.microsoft.com/en-us/library/windows/desktop/hh852750.aspx)</maml:linkText>
+			</maml:navigationLink>
+		</maml:relatedLinks>
+	</command>
+	<command xmlns:msh="http://msh" xmlns="http://schemas.microsoft.com/maml/dev/command/2004/10">
+		<details>
 			<name>Get-HelpXML</name>
 			<verb>Get</verb>
 			<noun>HelpXML</noun>
@@ -449,7 +543,7 @@
 		</returnValues>
 		<maml:alertSet>
 			<maml:alert>
-				<maml:para>Для записи HelpInfo.xml файла используйте Set-HelpInfoXML.</maml:para>
+				<maml:para>Для записи HelpInfo.xml файла используйте Set-HelpInfo.</maml:para>
 			</maml:alert>
 		</maml:alertSet>
 		<examples>
@@ -469,10 +563,10 @@
 				<maml:linkText>about_Updatable_Help</maml:linkText>
 			</maml:navigationLink>
 			<maml:navigationLink>
-				<maml:linkText>Set-HelpInfoXML</maml:linkText>
+				<maml:linkText>Set-HelpInfo</maml:linkText>
 			</maml:navigationLink>
 			<maml:navigationLink>
-				<maml:uri>http://github.com/IT-Service/ITG.Readme#New-HelpInfoXML</maml:uri>
+				<maml:uri>http://github.com/IT-Service/ITG.Readme#New-HelpInfo</maml:uri>
 			</maml:navigationLink>
 			<maml:navigationLink>
 				<maml:linkText>[HelpInfo XML Sample File](http://msdn.microsoft.com/en-us/library/windows/desktop/hh852750.aspx)</maml:linkText>

--- a/test.ps1
+++ b/test.ps1
@@ -12,7 +12,5 @@ Import-Module `
 Get-Readme -Module ( Get-Module 'ITG.Readme' ) -OutDefaultFile;
 Get-HelpXML -Module ( Get-Module 'ITG.Readme' ) -OutDefaultFile;
 
-New-HelpInfo -Module ( Get-Module 'ITG.Readme' ) `
-| % {
-	$_.OuterXml;
-};
+( New-HelpInfo -Module ( Get-Module 'ITG.Readme' ) ).OuterXml;
+( Get-HelpInfo -Module ( Get-Module 'ITG.Readme' ) ).OuterXml;


### PR DESCRIPTION
- `Get-HelpInfo` - возвращает XmlDocument файла HelpInfo.xml для указанного модуля

Ещё один шаг в решение #65.
